### PR TITLE
[FIX][iOS] All mediaTypes return order

### DIFF
--- a/ios/RNCCameraRollManager.m
+++ b/ios/RNCCameraRollManager.m
@@ -61,7 +61,8 @@ RCT_ENUM_CONVERTER(PHAssetCollectionSubtype, (@{
                   "'videos' or 'all'.", mediaType);
     }
     // This case includes the "all" mediatype
-    return nil;
+    PHFetchOptions *const options = [PHFetchOptions new];
+    return options;
   }
 }
 


### PR DESCRIPTION
This fixes the wrong return order when you fetch photos/videos (all) 